### PR TITLE
Postgres schemas should be taken into account when retrieving foreign keys

### DIFF
--- a/lib/foreigner/connection_adapters/postgresql_adapter.rb
+++ b/lib/foreigner/connection_adapters/postgresql_adapter.rb
@@ -30,6 +30,7 @@ module Foreigner
           WHERE tc.constraint_type = 'FOREIGN KEY'
             AND tc.constraint_catalog = '#{@config[:database]}'
             AND tc.table_name = '#{table_name}'
+            AND tc.table_schema = ANY (current_schemas(false))
         }
         
         fk_info.map do |row|


### PR DESCRIPTION
At the moment, when foreign keys are dumped to the _schema.rb_ file, all the postgres schemas are used.

I think only the current schemas should be considered, in the same way the _tables_ method in the postgres adapter of Active Record does.

See activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
