### PR TITLE
Fix undoing actions when unapplying a migration

### DIFF
--- a/lib/foreigner/migration/command_recorder.rb
+++ b/lib/foreigner/migration/command_recorder.rb
@@ -10,11 +10,11 @@ module Foreigner
       end
 
       def invert_add_foreign_key(*args)
-        [:remove_foreign_key, args]
+        [:remove_foreign_key, *args]
       end
       
       def invert_remove_foreign_key(*args)
-        [:add_foreign_key, args]
+        [:add_foreign_key, *args]
       end
     end
   end


### PR DESCRIPTION
If an attempt is made to undo a migration with

  def change
    add_foreign_key :tracks, :cds
  end

it will currently fail with the message:

  wrong number of arguments (1 for 2)

This is easily fixed by modifying the invert_\* methods in the
CommandRecorder module to expand the argument list that is returned in
the arrays.

I've tested this for both add_foreign_key and remove_foreign_key
