### PR TITLE
Fixed reversing add_foreign_key with :column => xxx

### DIFF
--- a/lib/foreigner/migration/command_recorder.rb
+++ b/lib/foreigner/migration/command_recorder.rb
@@ -2,11 +2,11 @@ module Foreigner
   module Migration
     module CommandRecorder
       def add_foreign_key(*args)
-        record(:add_foreign_key, *args)
+        record(:add_foreign_key, args)
       end
 
       def remove_foreign_key(*args)
-        record(:remove_foreign_key, *args)
+        record(:remove_foreign_key, args)
       end
 
       def invert_add_foreign_key(*args)

--- a/test/reversible_test.rb
+++ b/test/reversible_test.rb
@@ -8,29 +8,33 @@ class ReversibleTest < Foreigner::AdapterTest
   
   test 'invert_remove_foreign_key' do
     recorder = ActiveRecord::Migration::CommandRecorder.new
+    recorded = recorder.add_foreign_key(:table1, :table2)[0]
     assert_equal(
-      send(*recorder.add_foreign_key(:table1, :table2)[0]),
+      send(recorded[0], *recorded[1]),
       send(*recorder.invert_remove_foreign_key(:table1, :table2))
     )
   end
   test 'invert_remove_foreign_key with column' do
     recorder = ActiveRecord::Migration::CommandRecorder.new
+    recorded = recorder.add_foreign_key(:table1, :table2, :column => :column1)[0]
     assert_equal(
-      send(*recorder.add_foreign_key(:table1, :table2, :column => :column1)[0]),
+      send(recorded[0], *recorded[1]),
       send(*recorder.invert_remove_foreign_key(:table1, :table2, :column => :column1))
     )
   end
   test 'invert_add_foreign_key' do
     recorder = ActiveRecord::Migration::CommandRecorder.new
+    recorded = recorder.remove_foreign_key(:table1, :table2)[0]
     assert_equal(
-      send(*recorder.remove_foreign_key(:table1, :table2)[0]),
+      send(recorded[0], *recorded[1]),
       send(*recorder.invert_add_foreign_key(:table1, :table2))
     )
   end
   test 'invert_add_foreign_key with column' do
     recorder = ActiveRecord::Migration::CommandRecorder.new
+    recorded = recorder.remove_foreign_key(:table1, :table2, :column => :column1)[0]
     assert_equal(
-      send(*recorder.remove_foreign_key(:table1, :table2, :column => :column1)[0]),
+      send(recorded[0], *recorded[1]),
       send(*recorder.invert_add_foreign_key(:table1, :table2, :column => :column1))
     )
   end


### PR DESCRIPTION
Currently, reversing an add_foreign_key does not work if the :column is specified.
I've fixed this and also added a few tests for reversing.

Great work with this gem - thanks!
