### PR TITLE
Syntax error in Ruby 1.8.7

### DIFF
--- a/lib/foreigner/connection_adapters/sql2003.rb
+++ b/lib/foreigner/connection_adapters/sql2003.rb
@@ -26,7 +26,7 @@ module Foreigner
         sql
       end
 
-      def remove_foreign_key(table, to_table = nil, options)
+      def remove_foreign_key(table, to_table = nil, options = {})
         execute "ALTER TABLE #{quote_table_name(table)} #{remove_foreign_key_sql(table, options)}"
       end
 


### PR DESCRIPTION
/path/to/vendor/bundle/ruby/1.8/gems/foreigner-1.0.1/lib/foreigner/connection_adapters/mysql2_adapter.rb:4: /path/to/vendor/bundle/ruby/1.8/gems/foreigner-1.0.1/lib/foreigner/connection_adapters/sql2003.rb:29: syntax error, unexpected ')', expecting '=' (SyntaxError)
/home/infoman/work/dev/rails/sms.rails.dev.yo.md/vendor/bundle/ruby/1.8/gems/foreigner-1.0.1/lib/foreigner/connection_adapters/sql2003.rb:62: syntax error, unexpected kEND, expecting $end

This seems to fix it
