### PR TITLE
Add CASCADE to DROP TABLE when option :force is set

### DIFF
--- a/lib/foreigner/connection_adapters/sql2003.rb
+++ b/lib/foreigner/connection_adapters/sql2003.rb
@@ -39,6 +39,16 @@ module Foreigner
 
         "DROP CONSTRAINT #{quote_column_name(foreign_key_name)}"
       end
+      
+      def drop_table(table_name, options = {})
+        sql = "DROP TABLE #{quote_table_name(table_name)}"
+        if options[:force]
+         execute "#{sql} CASCADE"
+        else
+         execute sql
+        end
+      end
+      
 
       private
         def foreign_key_name(table, column, options = {})


### PR DESCRIPTION
This is my attempt at fixing issue #53, where DROP TABLE needs a CASCADE due to the foreign key constraint. It seems to work - rake db:setup now succeeds instead of erring out that "other objects depend on it" - but it's my first time monkeying about with ActiveRecord, so I'd appreciate if you took a peek before merging.
