### PR TITLE
fixed wrong number of arguments for drop_table

### DIFF
--- a/lib/foreigner/connection_adapters/mysql2_adapter.rb
+++ b/lib/foreigner/connection_adapters/mysql2_adapter.rb
@@ -3,7 +3,7 @@ module Foreigner
     module Mysql2Adapter
       include Foreigner::ConnectionAdapters::Sql2003
 
-      def drop_table(table_name)
+      def drop_table(table_name, options = {})
         execute "SET FOREIGN_KEY_CHECKS=0"
         execute "DROP TABLE #{quote_table_name(table_name)}"
         execute "SET FOREIGN_KEY_CHECKS=1"


### PR DESCRIPTION
When using drop_table during migrations in rails 3.1 we get: 

wrong number of arguments (2 for 1)
/Users/madmax/.rvm/gems/ruby-1.9.2-p180@peoplejar-rails31/bundler/gems/foreigner-a88d49a4f29d/lib/foreigner/connection_adapters/mysql2_adapter.rb:6:in `drop_table'
/Users/madmax/.rvm/gems/ruby-1.9.2-p180@peoplejar-rails31/gems/activerecord-3.1.0.rc4/lib/active_record/connection_adapters/mysql2_adapter.rb:444:in`drop_table'
/Users/madmax/.rvm/gems/ruby-1.9.2-p180@peoplejar-rails31/gems/activerecord-3.1.0.rc4/lib/active_record/connection_adapters/abstract/schema_statements.rb:164:in `create_table'

This commit will fix it. 
