### PR TITLE
Added support for JDBC Mysql adapter.

### DIFF
--- a/lib/foreigner.rb
+++ b/lib/foreigner.rb
@@ -22,6 +22,7 @@ end
 
 Foreigner::Adapter.register 'mysql', 'foreigner/connection_adapters/mysql_adapter'
 Foreigner::Adapter.register 'mysql2', 'foreigner/connection_adapters/mysql2_adapter'
+Foreigner::Adapter.register 'jdbcmysql', 'foreigner/connection_adapters/mysql2_adapter'
 Foreigner::Adapter.register 'postgresql', 'foreigner/connection_adapters/postgresql_adapter'
 
 require 'foreigner/railtie' if defined?(Rails)


### PR DESCRIPTION
This is a simple one-line fix that will use the Mysql2 adapter when you have "jdbcmysql" set as your adapter in database.yml.

On that note, some sort of "no adapter exists" message needs to be added, as currently, if one doesn't, "add_foreign_key" statements will run like they are successful, but don't actually do anything.
