### PR TITLE
Add support for the jdbcpostgresql adapter

### DIFF
--- a/lib/foreigner.rb
+++ b/lib/foreigner.rb
@@ -24,5 +24,6 @@ Foreigner::Adapter.register 'mysql', 'foreigner/connection_adapters/mysql_adapte
 Foreigner::Adapter.register 'mysql2', 'foreigner/connection_adapters/mysql2_adapter'
 Foreigner::Adapter.register 'jdbcmysql', 'foreigner/connection_adapters/mysql2_adapter'
 Foreigner::Adapter.register 'postgresql', 'foreigner/connection_adapters/postgresql_adapter'
+Foreigner::Adapter.register 'jdbcpostgresql', 'foreigner/connection_adapters/postgresql_adapter'
 
 require 'foreigner/railtie' if defined?(Rails)


### PR DESCRIPTION
Mirroring [jmcnevin commit for jdbcmysql](https://github.com/matthuhiggins/foreigner/commit/414be2beba05a27a68f7f67aed6ed39d3bda61dd), this adds support for jdbcpostgresql.

It was verified locally using:

activerecord-jdbcpostgresql-adapter (1.2.2)
jdbc-postgres (9.1.901)
