### PR TITLE
fix an example in remove_foreign_key docs

### DIFF
--- a/lib/foreigner/connection_adapters/abstract/schema_definitions.rb
+++ b/lib/foreigner/connection_adapters/abstract/schema_definitions.rb
@@ -44,7 +44,7 @@ module Foreigner
       #   end
       # ====== Remove the foreign key named party_foreign_key in the accounts table.
       #   change_table :accounts do |t|
-      #     t.remove_index name: :party_foreign_key
+      #     t.remove_foreign_key name: :party_foreign_key
       #   end
       def remove_foreign_key(options)
         @base.remove_foreign_key(@table_name, options)


### PR DESCRIPTION
the last example using the `name` option was usign `remove_index` instead of `remove_foreign_key`
