### PR TITLE
fix error for calling 'create_table' without block

### DIFF
--- a/lib/foreigner/connection_adapters/abstract/schema_statements.rb
+++ b/lib/foreigner/connection_adapters/abstract/schema_statements.rb
@@ -13,7 +13,7 @@ module Foreigner
         definition = nil
         super do |td|
           definition = td # This is my trick to get the definition
-          block.call(td)
+          block.call(td) unless block.nil?
         end
         definition.foreign_keys.each do |to_table, options_list|
           options_list.each do |options|


### PR DESCRIPTION
create_table can be used for creating table without columns. 
For example, this is used in the mini_record gem.
