### PR TITLE
Add support for add_foreign_key on multiple columns

### DIFF
--- a/lib/foreigner/connection_adapters/mysql2_adapter.rb
+++ b/lib/foreigner/connection_adapters/mysql2_adapter.rb
@@ -6,7 +6,7 @@ module Foreigner
       def remove_foreign_key_sql(table, options)
         foreign_key_name = decipher_foreign_key_name(table, options)
 
-        "DROP FOREIGN KEY #{quote_column_name(foreign_key_name)}"
+        "DROP FOREIGN KEY #{quote_column_names(foreign_key_name)}"
       end
 
       def foreign_keys(table_name)
@@ -26,7 +26,7 @@ module Foreigner
         fk_info.map do |row|
           options = {column: row['column'], name: row['name'], primary_key: row['primary_key']}
 
-          if create_table_info =~ /CONSTRAINT #{quote_column_name(row['name'])} FOREIGN KEY .* REFERENCES .* ON DELETE (CASCADE|SET NULL|RESTRICT)/
+          if create_table_info =~ /CONSTRAINT #{quote_column_names(row['name'])} FOREIGN KEY .* REFERENCES .* ON DELETE (CASCADE|SET NULL|RESTRICT)/
             options[:dependent] = case $1
               when 'CASCADE'  then :delete
               when 'SET NULL' then :nullify

--- a/test/foreigner/connection_adapters/sql2003_test.rb
+++ b/test/foreigner/connection_adapters/sql2003_test.rb
@@ -60,6 +60,13 @@ class Foreigner::Sql2003Test < Foreigner::UnitTest
     )
   end
 
+  test 'add_with_multiple_columns_and_keys' do
+    assert_equal(
+      "ALTER TABLE `employees` ADD CONSTRAINT `employees_bar_id_foo_id_fk` FOREIGN KEY (`bar_id`, `foo_id`) REFERENCES `companies`(id_one, id_two)",
+      @adapter.add_foreign_key(:employees, :companies, column: %w(bar_id foo_id), primary_key: %w(id_one id_two))
+    )
+  end
+
   test 'add_with_delete_dependency' do
     assert_equal(
       "ALTER TABLE `employees` ADD CONSTRAINT `employees_company_id_fk` FOREIGN KEY (`company_id`) REFERENCES `companies`(id) " +

--- a/test/foreigner/schema_dumper_test.rb
+++ b/test/foreigner/schema_dumper_test.rb
@@ -32,6 +32,8 @@ class Foreigner::SchemaDumperTest < Foreigner::UnitTest
     assert_dump "add_foreign_key \"foos\", \"bars\", name: \"lulz\", primary_key: \"uuid\"", Foreigner::ConnectionAdapters::ForeignKeyDefinition.new('foos', 'bars', column: 'bar_id', primary_key: 'uuid', name: 'lulz')
     assert_dump "add_foreign_key \"foos\", \"bars\", name: \"lulz\", dependent: :delete", Foreigner::ConnectionAdapters::ForeignKeyDefinition.new('foos', 'bars', column: 'bar_id', primary_key: 'id', name: 'lulz', dependent: :delete)
     assert_dump "add_foreign_key \"foos\", \"bars\", name: \"lulz\", column: \"mamma_id\"", Foreigner::ConnectionAdapters::ForeignKeyDefinition.new('foos', 'bars', column: 'mamma_id', primary_key: 'id', name: 'lulz')
+    assert_dump "add_foreign_key \"foos\", \"bars\", name: \"lulz\", column: [\"mamma_id\", \"papa_id\"], primary_key: [\"id\", \"papa_id\"]",
+      Foreigner::ConnectionAdapters::ForeignKeyDefinition.new('foos', 'bars', column: ['mamma_id', 'papa_id'], primary_key: ['id', 'papa_id'], name: 'lulz')
   end
 
   test 'all tables' do


### PR DESCRIPTION
This pull request allows you to add a foreign key on multiple columns using the `add_foreign_key` method. Simply specify the `column` and `primary_key` options as arrays of strings instead of strings.

For example, in order to enforce that only users with access to a project can create issues for it:

``` ruby
create_table :issues do |t|
  t.references :user
  t.references :project
end

add_foreign_key :issues, :project_access,
  column: %w(user_id project_id),
  primary_key: %w(user_id project_id)
```
