### PR TITLE
Preserve passed options in drop_table

### DIFF
--- a/lib/foreigner/connection_adapters/sql2003.rb
+++ b/lib/foreigner/connection_adapters/sql2003.rb
@@ -8,9 +8,9 @@ module Foreigner
       def drop_table(*args)
         options = args.extract_options!
         if options[:force]
-          disable_referential_integrity { super }
+          disable_referential_integrity { super(*(args.dup << options)) }
         else
-          super
+          super(*(args.dup << options))
         end
       end
 


### PR DESCRIPTION
`extract_options!` is a destructive method - the `super` call doesn’t
get the extracted options.
