### PR TITLE
Remove leading spaces in code examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The following adapters are supported:
 
 Add the following to your Gemfile:
 ```ruby
-  gem 'foreigner'
+gem 'foreigner'
 ```
 ## API Examples
 
@@ -26,33 +26,33 @@ Foreigner adds two methods to migrations.
 
 For example, given the following model:
 ```ruby
-  class Comment < ActiveRecord::Base
-    belongs_to :post
-  end
+class Comment < ActiveRecord::Base
+  belongs_to :post
+end
 
-  class Post < ActiveRecord::Base
-    has_many :comments, dependent: :delete_all
-  end
+class Post < ActiveRecord::Base
+  has_many :comments, dependent: :delete_all
+end
 ```  
 You should add a foreign key in your migration:
 ```ruby
-  add_foreign_key(:comments, :posts)
+add_foreign_key(:comments, :posts)
 ```
 The `:dependent` option can be moved from the `has_many` definition to the foreign key:
 ```ruby
-  add_foreign_key(:comments, :posts, dependent: :delete)
+add_foreign_key(:comments, :posts, dependent: :delete)
 ```
 If the column is named `article_id` instead of `post_id`, use the `:column` option:
 ```ruby
-  add_foreign_key(:comments, :posts, column: 'article_id')
+add_foreign_key(:comments, :posts, column: 'article_id')
 ```
 A name can be specified for the foreign key constraint:
 ```ruby
-  add_foreign_key(:comments, :posts, name: 'comment_article_foreign_key')
+add_foreign_key(:comments, :posts, name: 'comment_article_foreign_key')
 ```
 The `:column` and `:name` options create a foreign key with a custom name. In order to remove it you need to specify `:name`:
 ```ruby
-  remove_foreign_key(:comments, name: 'comment_article_foreign_key')
+remove_foreign_key(:comments, name: 'comment_article_foreign_key')
 ```
 ## Change Table Methods
 
@@ -60,29 +60,29 @@ Foreigner adds extra methods to `create_table` and `change_table`.
 
 Create a new table with a foreign key:
 ```ruby
-  create_table :products do |t|
-    t.string :name
-    t.integer :factory_id
-    t.foreign_key :factories
-  end
+create_table :products do |t|
+  t.string :name
+  t.integer :factory_id
+  t.foreign_key :factories
+end
 ```
 Add a missing foreign key to comments:
 ```ruby
-  change_table :comments do |t|
-    t.foreign_key :posts, dependent: :delete
-  end
+change_table :comments do |t|
+  t.foreign_key :posts, dependent: :delete
+end
 ```
 Remove an unwanted foreign key:
 ```ruby
-  change_table :comments do |t|
-    t.remove_foreign_key :users
-  end
+change_table :comments do |t|
+  t.remove_foreign_key :users
+end
 ```
 ## Database-specific options
 
 Database-specific options will never be supported by foreigner. You can add them using `:options`:
 ```ruby
-  add_foreign_key(:comments, :posts, options: 'ON UPDATE DEFERRED')
+add_foreign_key(:comments, :posts, options: 'ON UPDATE DEFERRED')
 ```
 ## Foreigner Add-ons
 


### PR DESCRIPTION
There were redundant leading spaces in code examples. Let's remove them.
