### PR TITLE
Add MIT license to gemspec

### DIFF
--- a/foreigner.gemspec
+++ b/foreigner.gemspec
@@ -3,6 +3,7 @@
 Gem::Specification.new do |s|
   s.name = 'foreigner'
   s.version = '1.6.1'
+  s.licenses = ['MIT']
   s.summary = 'Foreign Keys for Rails'
   s.description = 'Adds helpers to migrations and dumps foreign keys to schema.rb'
 


### PR DESCRIPTION
Adds a reference to the MIT license, removing the following message during gem installation:

WARNING:  licenses is empty, but is recommended.  Use a license abbreviation from:
http://opensource.org/licenses/alphabetical
