### PR TITLE
Update the runtime dependency for ActiveRecord

### DIFF
--- a/foreigner.gemspec
+++ b/foreigner.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project = 'foreigner'
 
   s.files = %w(MIT-LICENSE Rakefile README.md) + Dir['lib/**/*.rb'] + Dir['test/**/*.rb']
-  s.add_dependency('activerecord', '>= 3.0.0')
+  s.add_runtime_dependency('activerecord', '~> 3.0', '>= 3.0.0')
   s.add_development_dependency('rake')
   s.add_development_dependency('mocha')
 end


### PR DESCRIPTION
Resolves the error message:

ERROR:  While executing gem ... (Gem::InvalidSpecificationException)
    duplicate dependency on activerecord (>= 3.1.0, development), (>= 3.0.0) use:
    add_runtime_dependency 'activerecord', '>= 3.1.0', '>= 3.0.0'