### PR TITLE
Add autoloading support for standalone_migrations gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,3 @@
 source "http://rubygems.org"
 
 gemspec
-
-group :test do
-  gem 'rails', '~> 4'
-  gem 'mocha', require: false
-  gem 'rake'
-end

--- a/foreigner.gemspec
+++ b/foreigner.gemspec
@@ -16,7 +16,11 @@ Gem::Specification.new do |s|
   s.rubyforge_project = 'foreigner'
 
   s.files = %w(MIT-LICENSE Rakefile README.md) + Dir['lib/**/*.rb'] + Dir['test/**/*.rb']
-  s.add_dependency('activerecord', '>= 3.0.0')
+  s.add_runtime_dependency('activerecord', '>= 3.0.0')
+  
   s.add_development_dependency('rake')
   s.add_development_dependency('mocha')
+  s.add_development_dependency('rails')
+  s.add_development_dependency('standalone_migrations')
+  s.add_development_dependency('debugger')
 end

--- a/lib/foreigner.rb
+++ b/lib/foreigner.rb
@@ -34,3 +34,4 @@ Foreigner::Adapter.register 'sqlite3', 'foreigner/connection_adapters/noop_adapt
 
 require 'foreigner/loader'
 require 'foreigner/railtie' if defined?(Rails)
+require 'foreigner/standalone_migrations' if defined?(StandaloneMigrations)

--- a/lib/foreigner/standalone_migrations.rb
+++ b/lib/foreigner/standalone_migrations.rb
@@ -1,0 +1,15 @@
+module Foreigner
+  def self.standalone_migrations_autoload_supported?
+    StandaloneMigrations.respond_to? :on_load
+  end
+
+  def self.load_standalone_migrations_autoloader
+    if standalone_migrations_autoload_supported?
+      StandaloneMigrations.on_load do
+        Foreigner.load
+      end
+    end
+  end
+end
+
+Foreigner.load_standalone_migrations_autoloader

--- a/test/foreigner/autoload_test.rb
+++ b/test/foreigner/autoload_test.rb
@@ -1,0 +1,27 @@
+class AutoloadTest < ActiveSupport::TestCase
+  test "autoloads for standalone migrations" do
+    # this should not exist
+    assert_raise NameError do
+      StandaloneMigrations
+    end
+
+    # and if it were to exist
+    require 'standalone_migrations'
+    StandaloneMigrations.expects(:on_load)
+    load 'foreigner.rb'
+
+    assert_equal(Foreigner.standalone_migrations_autoload_supported?, true)
+  end
+
+  test "autoloads for rails" do
+    # this should not exist
+    assert_raise NameError do
+      Foreigner::Railtie
+    end
+
+    require 'rails'
+    load 'foreigner.rb'
+
+    assert_not_nil(Foreigner::Railtie)
+  end
+end


### PR DESCRIPTION
I created a [pull request](https://github.com/thuss/standalone-migrations/pull/100) for the [standalone_migrations gem](https://github.com/thuss/standalone-migrations).  That pull request added support for an on_load callback.

This pull request is to add the ability for foreigner to be properly loaded (`Foreigner.load`) when somebody is using the standalone_migrations gem.  Similar functionality is provided for rails.

I also added tests to ensure that the foreigner autoloaders for both rails and standalone_migrations are loaded only if the respective library is loaded.  If `on_load` is not supported with standalone_migrations, this gem will not be loaded.
