### PR TITLE
Add support for composite keys

### DIFF
--- a/test/foreigner/connection_adapters/sql2003_test.rb
+++ b/test/foreigner/connection_adapters/sql2003_test.rb
@@ -71,6 +71,14 @@ class Foreigner::Sql2003Test < Foreigner::UnitTest
     )
   end
 
+  test 'add_with_composite_column_and_key' do
+    assert_equal(
+      "ALTER TABLE `users` ADD CONSTRAINT `users_primary_phone_id_id_fk` FOREIGN KEY (`primary_phone_id`, `id`) REFERENCES `phones_users`(phone_id, user_id)",
+      @adapter.add_foreign_key(:users, :phones_users, column: [
+      'primary_phone_id', 'id'], primary_key: ['phone_id', 'user_id'])
+    )
+  end
+
   test 'add_with_column_and_name' do
     assert_equal(
       "ALTER TABLE `employees` ADD CONSTRAINT `favorite_company_fk` FOREIGN KEY (`last_employer_id`) REFERENCES `companies`(id)",
@@ -144,6 +152,13 @@ class Foreigner::Sql2003Test < Foreigner::UnitTest
     assert_equal(
       "ALTER TABLE `suppliers` DROP CONSTRAINT `suppliers_ship_to_id_fk`",
       @adapter.remove_foreign_key(:suppliers, column: "ship_to_id")
+    )
+  end
+
+  test 'remove_by_composite_key' do
+    assert_equal(
+      "ALTER TABLE `users` DROP CONSTRAINT `users_primary_phone_id_id_fk`",
+      @adapter.remove_foreign_key(:users, column: ['primary_phone_id', 'id'])
     )
   end
 end

--- a/test/foreigner/schema_dumper_test.rb
+++ b/test/foreigner/schema_dumper_test.rb
@@ -33,6 +33,10 @@ class Foreigner::SchemaDumperTest < Foreigner::UnitTest
     assert_dump "add_foreign_key \"foos\", \"bars\", name: \"lulz\", dependent: :delete", Foreigner::ConnectionAdapters::ForeignKeyDefinition.new('foos', 'bars', column: 'bar_id', primary_key: 'id', name: 'lulz', dependent: :delete)
     assert_dump "add_foreign_key \"foos\", \"bars\", name: \"lulz\", column: \"mamma_id\"", Foreigner::ConnectionAdapters::ForeignKeyDefinition.new('foos', 'bars', column: 'mamma_id', primary_key: 'id', name: 'lulz')
     assert_dump "add_foreign_key \"foos\", \"bars\", name: \"lulz\", options: \"YOLO MAYBE DB-SPECIFIC!\"", Foreigner::ConnectionAdapters::ForeignKeyDefinition.new('foos', 'bars', column: 'bar_id', primary_key: 'id', name: 'lulz', options: "YOLO MAYBE DB-SPECIFIC!")
+    assert_dump "add_foreign_key \"foos\", \"bars\", name: \"lulz\", column: [\"a_id\", \"b_id\"], primary_key: [\"c_id\", \"d_id\"]",
+    Foreigner::ConnectionAdapters::ForeignKeyDefinition.new('foos',
+    'bars', column: ['a_id', 'b_id'], primary_key: ['c_id', 'd_id'],
+    name: 'lulz')
   end
 
   test 'all tables' do


### PR DESCRIPTION
Allow composite keys to be specified by passing an array to the column and primary_key option
