### PR TITLE
Prevent parsing comma in MySQL `SHOW CREATE TABLE` output

### DIFF
--- a/lib/foreigner/connection_adapters/mysql2_adapter.rb
+++ b/lib/foreigner/connection_adapters/mysql2_adapter.rb
@@ -26,13 +26,13 @@ module Foreigner
         fk_info.map do |row|
           options = {column: row['column'], name: row['name'], primary_key: row['primary_key']}
 
-          if create_table_info =~ /CONSTRAINT #{quote_column_name(row['name'])} FOREIGN KEY .* REFERENCES .*\)( ON DELETE (CASCADE|SET NULL|RESTRICT))? ?(.*)$/
-            options[:dependent] = case $2
+          if create_table_info =~ /CONSTRAINT #{quote_column_name(row['name'])} FOREIGN KEY .* REFERENCES .*\)(?: ON DELETE (CASCADE|SET NULL|RESTRICT))?(?: (.+?))?,?$/
+            options[:dependent] = case $1
               when 'CASCADE'  then :delete
               when 'SET NULL' then :nullify
               when 'RESTRICT' then :restrict
             end
-            options[:options] = $3 # e.g. ON UPDATE ...
+            options[:options] = $2 # e.g. ON UPDATE ...
           end
           ForeignKeyDefinition.new(table_name, row['to_table'], options)
         end


### PR DESCRIPTION
When a foreign key has no ON DELETE or additional options, and is followed by
a comma (i.e. the first of many), then the trailing comma was incorrectly
parsed as a constraint option.  This caused `options: ","` to appear in
schema.rb.

---

This caused failures when running Rails tests, as it tried adding a foreign key with "," options when setting up the test database, as the following trace shows:

<pre>
ActiveRecord::StatementInvalid: Mysql2::Error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '' at line 1: ALTER TABLE `architectures_operatingsystems` ADD CONSTRAINT `architectures_operatingsystems_operatingsystem_id_fk` FOREIGN KEY (`operatingsystem_id`) REFERENCES `operatingsystems`(id) ,
/usr/local/rvm/gems/ruby-1.9.3-p392@test_develop_pr_core-1/gems/activerecord-3.2.21/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:245:in `query'
/usr/local/rvm/gems/ruby-1.9.3-p392@test_develop_pr_core-1/gems/activerecord-3.2.21/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:245:in `block in execute'
/usr/local/rvm/gems/ruby-1.9.3-p392@test_develop_pr_core-1/gems/activerecord-3.2.21/lib/active_record/connection_adapters/abstract_adapter.rb:280:in `block in log'
/usr/local/rvm/gems/ruby-1.9.3-p392@test_develop_pr_core-1/gems/activesupport-3.2.21/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
/usr/local/rvm/gems/ruby-1.9.3-p392@test_develop_pr_core-1/gems/activerecord-3.2.21/lib/active_record/connection_adapters/abstract_adapter.rb:275:in `log'
/usr/local/rvm/gems/ruby-1.9.3-p392@test_develop_pr_core-1/gems/activerecord-3.2.21/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:245:in `execute'
/usr/local/rvm/gems/ruby-1.9.3-p392@test_develop_pr_core-1/gems/activerecord-3.2.21/lib/active_record/connection_adapters/mysql2_adapter.rb:213:in `execute'
/usr/local/rvm/gems/ruby-1.9.3-p392@test_develop_pr_core-1/gems/foreigner-1.7.0/lib/foreigner/connection_adapters/sql2003.rb:24:in `add_foreign_key'
/usr/local/rvm/gems/ruby-1.9.3-p392@test_develop_pr_core-1/gems/activerecord-3.2.21/lib/active_record/migration.rb:466:in `block in method_missing'
/usr/local/rvm/gems/ruby-1.9.3-p392@test_develop_pr_core-1/gems/activerecord-3.2.21/lib/active_record/migration.rb:438:in `block in say_with_time'
/usr/local/rvm/gems/ruby-1.9.3-p392@test_develop_pr_core-1/gems/activerecord-3.2.21/lib/active_record/migration.rb:438:in `say_with_time'
/usr/local/rvm/gems/ruby-1.9.3-p392@test_develop_pr_core-1/gems/activerecord-3.2.21/lib/active_record/migration.rb:458:in `method_missing'
/var/lib/workspace/workspace/test_develop_pr_core/database/mysql/ruby/1.9.3/db/schema.rb:913:in `block in <top (required)>'
/usr/local/rvm/gems/ruby-1.9.3-p392@test_develop_pr_core-1/gems/activerecord-3.2.21/lib/active_record/schema.rb:50:in `instance_eval'
/usr/local/rvm/gems/ruby-1.9.3-p392@test_develop_pr_core-1/gems/activerecord-3.2.21/lib/active_record/schema.rb:50:in `define'
/var/lib/workspace/workspace/test_develop_pr_core/database/mysql/ruby/1.9.3/db/schema.rb:14:in `<top (required)>'
</pre>


@GregSutcliffe is going to test this patch to make sure our tests pass now.  It'd be great if you could release a 1.7.1 with the fix, as 1.7.0 has introduced the problem.
