### PR TITLE
Ensure Foreigner is loaded for Rails 4.1.9

### DIFF
--- a/lib/foreigner.rb
+++ b/lib/foreigner.rb
@@ -33,4 +33,5 @@ Foreigner::Adapter.register 'jdbcpostgresql', 'foreigner/connection_adapters/pos
 Foreigner::Adapter.register 'sqlite3', 'foreigner/connection_adapters/noop_adapter'
 
 require 'foreigner/loader'
+require 'foreigner/helper'
 require 'foreigner/railtie' if defined?(Rails)

--- a/lib/foreigner/helper.rb
+++ b/lib/foreigner/helper.rb
@@ -1,0 +1,13 @@
+module Foreigner
+  module Helper
+    def self.active_record_version
+      if ::ActiveRecord.respond_to? :version
+        ActiveRecord.version.to_s
+      elsif ::ActiveRecord::VERSION
+        ::ActiveRecord::VERSION
+      else
+        raise "Unknown ActiveRecord Version API"
+      end
+    end
+  end
+end

--- a/lib/foreigner/schema_dumper.rb
+++ b/lib/foreigner/schema_dumper.rb
@@ -42,6 +42,10 @@ module Foreigner
 
     def tables_with_foreign_keys(stream)
       tables_without_foreign_keys(stream)
+      # Ensure Foreigner to be initialized before running foreign_keys.
+      # This is required since schema::load is not initializing the environment
+      # anymore in Rails 4.1.9 (https://github.com/rails/rails/commit/5d6bb89f)
+      stream.puts '  Foreigner.load' if Foreigner::Helper.active_record_version == '4.1.9'
       @connection.tables.sort.each do |table|
         next if ['schema_migrations', ignore_tables].flatten.any? do |ignored|
           case ignored

--- a/test/foreigner/schema_dumper_test.rb
+++ b/test/foreigner/schema_dumper_test.rb
@@ -11,7 +11,7 @@ class Foreigner::SchemaDumperTest < Foreigner::UnitTest
   class MockSchemaDumper
     cattr_accessor :ignore_tables
 
-    attr_accessor :processed_tables
+    attr_accessor :processed_tables, :stream
     def initialize
       @connection = MockConnection.new
       @processed_tables = []
@@ -21,6 +21,7 @@ class Foreigner::SchemaDumperTest < Foreigner::UnitTest
     end
 
     def foreign_keys(table, stream)
+      self.stream = stream
       processed_tables << table
     end
 
@@ -47,6 +48,15 @@ class Foreigner::SchemaDumperTest < Foreigner::UnitTest
     dumper = MockSchemaDumper.new
     dumper.tables(StringIO.new)
     assert_equal ['bar'].to_set, dumper.processed_tables.to_set
+  end
+
+  test '4.1.9 loading error' do
+    Foreigner::Helper.stubs(:active_record_version).returns("4.1.9")
+    MockSchemaDumper.ignore_tables = []
+    dumper = MockSchemaDumper.new
+    dumper.tables(StringIO.new)
+
+    assert_match(/Foreigner\.load/, dumper.stream.string)
   end
 
   test 'removes table name suffix and prefix' do


### PR DESCRIPTION
When using Foreigner on Rails 4.1.9 and trying to run `schema::load` Foreigner has not been initialized yet so this methods don't exist.

This change was introduced by the following Rails commit:

* https://github.com/rails/rails/commit/5d6bb89f

So in order to ensure Foreigner has been initialized and methods are
present for `schema::load` to work correctly, we include `Foreigner.load`
inside the `schema.rb` file before any of the foreign key methods.