### PR TITLE
Add support for Apartment gem

### DIFF
--- a/lib/foreigner/schema_dumper.rb
+++ b/lib/foreigner/schema_dumper.rb
@@ -8,7 +8,7 @@ module Foreigner
 
     module ClassMethods
       def dump_foreign_key(foreign_key)
-        statement_parts = [ ('add_foreign_key ' + remove_prefix_and_suffix(foreign_key.from_table).inspect) ]
+        statement_parts = [ ('add_foreign_key ' + maybe_prepend_apartment_schema_name(remove_prefix_and_suffix(foreign_key.from_table)).inspect) ]
         statement_parts << maybe_prepend_apartment_schema_name(remove_prefix_and_suffix(foreign_key.to_table)).inspect
         statement_parts << ('name: ' + foreign_key.options[:name].inspect)
 

--- a/lib/foreigner/schema_dumper.rb
+++ b/lib/foreigner/schema_dumper.rb
@@ -9,10 +9,10 @@ module Foreigner
     module ClassMethods
       def dump_foreign_key(foreign_key)
         statement_parts = [ ('add_foreign_key ' + remove_prefix_and_suffix(foreign_key.from_table).inspect) ]
-        statement_parts << maybe_prepend_public(remove_prefix_and_suffix(foreign_key.to_table)).inspect
+        statement_parts << maybe_prepend_apartment_schema_name(remove_prefix_and_suffix(foreign_key.to_table)).inspect
         statement_parts << ('name: ' + foreign_key.options[:name].inspect)
 
-        if foreign_key.options[:column] != "#{maybe_prepend_public(remove_prefix_and_suffix(foreign_key.to_table)).singularize}_id"
+        if foreign_key.options[:column] != "#{maybe_prepend_apartment_schema_name(remove_prefix_and_suffix(foreign_key.to_table)).singularize}_id"
           statement_parts << ('column: ' + foreign_key.options[:column].inspect)
         end
         if foreign_key.options[:primary_key] != 'id'
@@ -39,9 +39,10 @@ module Foreigner
       end
       module_function :remove_prefix_and_suffix
 
-      def maybe_prepend_public(table_name)
-        if Object.const_defined?(:Apartment) && Apartment.excluded_models.map { |m| m.constantize.table_name.gsub /^public\./, '' }.include?(table_name)
-          "public.#{table_name}"
+      def maybe_prepend_apartment_schema_name(table_name)
+
+        if Object.const_defined?(:Apartment) && Apartment.excluded_models.map { |m| m.constantize.table_name.gsub /^#{Apartment.default_schema}\./, '' }.include?(table_name)
+          "#{Apartment.default_schema}.#{table_name}"
         else
           table_name
         end

--- a/lib/foreigner/schema_dumper.rb
+++ b/lib/foreigner/schema_dumper.rb
@@ -9,10 +9,10 @@ module Foreigner
     module ClassMethods
       def dump_foreign_key(foreign_key)
         statement_parts = [ ('add_foreign_key ' + remove_prefix_and_suffix(foreign_key.from_table).inspect) ]
-        statement_parts << remove_prefix_and_suffix(foreign_key.to_table).inspect
+        statement_parts << maybe_prepend_public(remove_prefix_and_suffix(foreign_key.to_table)).inspect
         statement_parts << ('name: ' + foreign_key.options[:name].inspect)
 
-        if foreign_key.options[:column] != "#{remove_prefix_and_suffix(foreign_key.to_table).singularize}_id"
+        if foreign_key.options[:column] != "#{maybe_prepend_public(remove_prefix_and_suffix(foreign_key.to_table)).singularize}_id"
           statement_parts << ('column: ' + foreign_key.options[:column].inspect)
         end
         if foreign_key.options[:primary_key] != 'id'
@@ -38,6 +38,14 @@ module Foreigner
         end
       end
       module_function :remove_prefix_and_suffix
+
+      def maybe_prepend_public(table_name)
+        if Object.const_defined?(:Apartment) && Apartment.excluded_models.map { |m| m.constantize.table_name.gsub /^public\./, '' }.include?(table_name)
+          "public.#{table_name}"
+        else
+          table_name
+        end
+      end
     end
 
     def requires_foreigner_load?

--- a/test/foreigner/schema_dumper_test.rb
+++ b/test/foreigner/schema_dumper_test.rb
@@ -73,10 +73,20 @@ class Foreigner::SchemaDumperTest < Foreigner::UnitTest
     begin
       class ::Apartment
         def self.excluded_models
-          ["Diagnosis"]
+          ["Diagnosis", "Role", "RoleUser"]
         end
         def self.default_schema
-          :public
+          "public"
+        end
+      end
+      class ::Role
+        def self.table_name
+          "public.roles"
+        end
+      end
+      class ::RoleUser
+        def self.table_name
+          "public.roles_users"
         end
       end
       class ::Diagnosis
@@ -84,8 +94,16 @@ class Foreigner::SchemaDumperTest < Foreigner::UnitTest
           "public.diagnoses"
         end
       end
+
       assert_dump "add_foreign_key \"send_vet_prescription_items\", \"public.diagnoses\", name: \"send_vet_prescription_items_diagnosis_id_fk\", column: \"diagnosis_id\"",
         Foreigner::ConnectionAdapters::ForeignKeyDefinition.new('send_vet_prescription_items', 'diagnoses', column: 'diagnosis_id', primary_key: 'id', name: 'send_vet_prescription_items_diagnosis_id_fk')
+
+      assert_dump "add_foreign_key \"public.roles_users\", \"public.roles\", name: \"roles_users_role_id_fk\", column: \"role_id\", dependent: :delete",
+        Foreigner::ConnectionAdapters::ForeignKeyDefinition.new('public.roles_users', 'public.roles', column: 'role_id', primary_key: 'id', dependent: :delete, name: 'roles_users_role_id_fk')
+
+      assert_dump "add_foreign_key \"public.roles_users\", \"public.roles\", name: \"roles_users_role_id_fk\", column: \"role_id\", dependent: :delete",
+        Foreigner::ConnectionAdapters::ForeignKeyDefinition.new('roles_users', 'roles', column: 'role_id', primary_key: 'id', dependent: :delete, name: 'roles_users_role_id_fk')
+
     ensure
       Object.send(:remove_const, :Apartment)
       Object.send(:remove_const, :Diagnosis)
@@ -97,4 +115,3 @@ class Foreigner::SchemaDumperTest < Foreigner::UnitTest
       assert_equal expected, MockSchemaDumper.dump_foreign_key(definition)
     end
 end
-

--- a/test/foreigner/schema_dumper_test.rb
+++ b/test/foreigner/schema_dumper_test.rb
@@ -75,6 +75,9 @@ class Foreigner::SchemaDumperTest < Foreigner::UnitTest
         def self.excluded_models
           ["Diagnosis"]
         end
+        def self.default_schema
+          :public
+        end
       end
       class ::Diagnosis
         def self.table_name

--- a/test/foreigner/schema_dumper_test.rb
+++ b/test/foreigner/schema_dumper_test.rb
@@ -69,6 +69,26 @@ class Foreigner::SchemaDumperTest < Foreigner::UnitTest
     end
   end
 
+  test 'appends "public." to Apartment excluded models' do
+    begin
+      class ::Apartment
+        def self.excluded_models
+          ["Diagnosis"]
+        end
+      end
+      class ::Diagnosis
+        def self.table_name
+          "public.diagnoses"
+        end
+      end
+      assert_dump "add_foreign_key \"send_vet_prescription_items\", \"public.diagnoses\", name: \"send_vet_prescription_items_diagnosis_id_fk\", column: \"diagnosis_id\"",
+        Foreigner::ConnectionAdapters::ForeignKeyDefinition.new('send_vet_prescription_items', 'diagnoses', column: 'diagnosis_id', primary_key: 'id', name: 'send_vet_prescription_items_diagnosis_id_fk')
+    ensure
+      Object.send(:remove_const, :Apartment)
+      Object.send(:remove_const, :Diagnosis)
+    end
+  end
+
   private
     def assert_dump(expected, definition)
       assert_equal expected, MockSchemaDumper.dump_foreign_key(definition)


### PR DESCRIPTION
Add support for Apartment gem with excluded models -- tables of which exist in public schema.

If Apartment class is defined, excluded models are inspected. In case the current table that we are generating foreign keys for is one of the excluded tables, it means it needs to have 'public.' prepended to it's table name
