### PR TITLE
Fix ActiveRecord version retrieval on Rails 3

### DIFF
--- a/lib/foreigner/helper.rb
+++ b/lib/foreigner/helper.rb
@@ -3,8 +3,8 @@ module Foreigner
     def self.active_record_version
       if ::ActiveRecord.respond_to? :version
         ActiveRecord.version
-      elsif ::ActiveRecord::VERSION
-        Gem::Version.new(::ActiveRecord::VERSION)
+      elsif ::ActiveRecord::VERSION::STRING
+        Gem::Version.new(::ActiveRecord::VERSION::STRING)
       else
         raise "Unknown ActiveRecord Version API"
       end


### PR DESCRIPTION
In 1.7.3, a889deb tries to create a Gem::Version out of a module rather than
the full version string, causing this during a db:schema:dump:

    ArgumentError: Malformed version number string ActiveRecord::VERSION

This fixes broken tests (https://travis-ci.org/matthuhiggins/foreigner/builds/56370433)
and db:migrate on Rails 3.2.

A release for 1.7.x would be much appreciated too.