### PR TITLE
Specify name so that sql is correctly filtered from log

### DIFF
--- a/lib/foreigner/connection_adapters/mysql2_adapter.rb
+++ b/lib/foreigner/connection_adapters/mysql2_adapter.rb
@@ -19,9 +19,9 @@ module Foreigner
           WHERE fk.referenced_column_name is not null
             AND fk.table_schema = '#{@config[:database]}'
             AND fk.table_name = '#{table_name}'
-        }
+        }, 'SCHEMA'
 
-        create_table_info = select_one("SHOW CREATE TABLE #{quote_table_name(table_name)}")["Create Table"]
+        create_table_info = select_one("SHOW CREATE TABLE #{quote_table_name(table_name)}", 'SCHEMA')["Create Table"]
 
         fk_info.map do |row|
           options = {column: row['column'], name: row['name'], primary_key: row['primary_key']}


### PR DESCRIPTION
Sql is given a name so that it can be filtered. Schema related sql is given the name 'SCHEMA' which is filtered by default. If no name is given then the sql it isn't filtered out. 

I have only made the change to the mysql2 adapter, because that is the only one I use and can test. 
