### PR TITLE
Use puts instead of p for multi-line message

### DIFF
--- a/lib/foreigner/adapter.rb
+++ b/lib/foreigner/adapter.rb
@@ -12,8 +12,8 @@ module Foreigner
         if registered.key?(configured_name)
           require registered[configured_name]
         else
-          p "Database adapter #{configured_name} not supported. Use:\n" +
-            "Foreigner::Adapter.register '#{configured_name}', 'path/to/adapter'"
+          puts "Database adapter #{configured_name} not supported. Use:\n" +
+               "Foreigner::Adapter.register '#{configured_name}', 'path/to/adapter'"
         end
       end
 

--- a/test/foreigner/adapter_test.rb
+++ b/test/foreigner/adapter_test.rb
@@ -8,4 +8,22 @@ class Foreigner::AdapterTest < ActiveSupport::TestCase
 
     Foreigner::Adapter.load!
   end
+
+  test "load prints warning message for an unsupported adapter on two lines" do
+    Foreigner::Adapter.stubs(:configured_name).returns('unsupported')
+
+    output = StringIO.new
+    with_stdout(output) { Foreigner::Adapter.load! }
+
+    assert_equal 2, output.string.split("\n").length
+  end
+
+  private
+  def with_stdout(stream)
+    oldstdout = $stdout
+    $stdout = stream
+    yield
+  ensure
+    $stdout = oldstdout
+  end
 end


### PR DESCRIPTION
`Kernel#p` [calls `#inspect` on its argument before writing it to the output](http://ruby-doc.org/core-2.2.2/Kernel.html#method-i-p), so the warning message for an unsupported adapter is displayed like this:

```
"Database adapter seamless_database_pool not supported. Use:\nForeigner::Adapter.register 'seamless_database_pool', 'path/to/adapter'"
```

This PR changes the `p` to a `puts`, so the message displayed is:

```
Database adapter seamless_database_pool not supported. Use:
Foreigner::Adapter.register 'seamless_database_pool', 'path/to/adapter'
```

as intended.

*Note*: `capture(stream)` [is deprecated](https://github.com/rails/rails/blob/e595d91ac2c07371b441f8b04781e7c03ac44135/activesupport/lib/active_support/core_ext/kernel/reporting.rb#L89-L91), which is why the test uses a `StringIO` to capture the output instead of calling that method.