### PR TITLE
Fix deprecation warning from ActiveSupport for Kernel#capture

### DIFF
--- a/test/foreigner/adapter_test.rb
+++ b/test/foreigner/adapter_test.rb
@@ -1,6 +1,6 @@
 require 'helper'
 
-class Foreigner::AdapterTest < ActiveSupport::TestCase
+class Foreigner::AdapterTest < Foreigner::UnitTest
   test "load" do
     Foreigner::Adapter.register 'foo', 'bar'
     Foreigner::Adapter.expects(:configured_name).at_least_once.returns('foo')

--- a/test/foreigner/connection_adapters/mysql_adapter_test.rb
+++ b/test/foreigner/connection_adapters/mysql_adapter_test.rb
@@ -2,10 +2,10 @@ require 'helper'
 
 class Foreigner::MysqlAdapterTest < Foreigner::UnitTest
   test 'warning' do
-    skip unless respond_to?(:capture) # < not available until 3.1.x
-    output = capture(:stdout) do
+    output = StringIO.new
+    with_stdout(output) do
       require 'foreigner/connection_adapters/mysql_adapter'
     end
-    assert_match /WARNING: Please upgrade to mysql2. The old mysql adapter is not supported by foreigner./, output
+    assert_match /WARNING: Please upgrade to mysql2. The old mysql adapter is not supported by foreigner./, output.string
   end
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -44,6 +44,14 @@ end
 
 module Foreigner
   class UnitTest < ActiveSupport::TestCase
+    private
+    def with_stdout(stream)
+      oldstdout = $stdout
+      $stdout = stream
+      yield
+    ensure
+      $stdout = oldstdout
+    end
   end
 
   class IntegrationTest < ActiveSupport::TestCase


### PR DESCRIPTION
Fixes the ActiveSupport deprecation warning:

```
DEPRECATION WARNING: `#capture(stream)` is deprecated and will be removed in the next release. (called from block in <class:MysqlAdapterTest> at /Users/vladimir/code/foreigner/test/foreigner/connection_adapters/mysql_adapter_test.rb:6)
```

by moving away from `capture` and using `Foreigner::UnitTest#with_stdout`. In the process, moves `Foreigner::AdapterTest` to be a subclass of `Foreigner::UnitTest` so this method is available.

*Note*: If this PR is accepted before #172, I will refactor that code to just use the `Foreigner::UnitTest#with_stdout` method instead of defining it on `AdapterTest`.