### PR TITLE
Set ActiveSupport::TestCase.test_order to avoid warning

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -42,6 +42,10 @@ module TestAdapterMethods
     end
 end
 
+if ActiveSupport::TestCase.respond_to?(:test_order=)
+  ActiveSupport::TestCase.test_order = :random
+end
+
 module Foreigner
   class UnitTest < ActiveSupport::TestCase
   end


### PR DESCRIPTION
Running the tests shows the following warning:

```
DEPRECATION WARNING: You did not specify a value for the configuration option `active_support.test_order`. In Rails 5, the default value of this option will change from `:sorted` to `:random`.
To disable this warning and keep the current behavior, you can add the following line to your `config/environments/test.rb`:

  Rails.application.configure do
    config.active_support.test_order = :sorted
  end

Alternatively, you can opt into the future behavior by setting this option to `:random`. (called from test_order at /Users/vladimir/code/foreigner/.bundle/gems/gems/activesupport-4.2.1/lib/active_support/test_case.rb:42)
```

this PR fixes that by setting the test order to `:random` (effectively following the second advice in the warning, and opting into the future behavior).