### PR TITLE
Foreigner compatibility with schema specified

### DIFF
--- a/lib/foreigner/connection_adapters/postgresql_adapter.rb
+++ b/lib/foreigner/connection_adapters/postgresql_adapter.rb
@@ -5,9 +5,8 @@ module Foreigner
 
       DEPENDENCY_CODE_ACTIONS = {'c' => 'CASCADE', 'n' => 'SET NULL', 'r' => 'RESTRICT', 'd' => 'SET DEFAULT'}
 
-      def foreign_keys(table_name)
-        table_name_without_schema = table_name.split('.').last
-        schema_name = table_name.split('.').first
+      def foreign_keys(table_name_with_or_without_schema_name)
+        table_name, _schema_name, namespace_name = get_db_object_names(table_name_with_or_without_schema_name)
 
         fk_info = select_all %{
           SELECT t2.relname AS to_table
@@ -26,8 +25,8 @@ module Foreigner
           JOIN pg_attribute a2 ON a2.attnum = c.confkey[1] AND a2.attrelid = t2.oid
           JOIN pg_namespace t3 ON c.connamespace = t3.oid
           WHERE c.contype = 'f'
-            AND t1.relname = '#{table_name_without_schema}'
-            AND t3.nspname = #{ explicit_schema?(table_name) ? "'"+ schema_name +"'" : "ANY (current_schemas(false))" }
+            AND t1.relname = '#{table_name}'
+            AND t3.nspname = #{namespace_name}
           ORDER BY c.conname
         }
 

--- a/lib/foreigner/connection_adapters/postgresql_adapter.rb
+++ b/lib/foreigner/connection_adapters/postgresql_adapter.rb
@@ -6,6 +6,7 @@ module Foreigner
       DEPENDENCY_CODE_ACTIONS = {'c' => 'CASCADE', 'n' => 'SET NULL', 'r' => 'RESTRICT', 'd' => 'SET DEFAULT'}
 
       def foreign_keys(table_name_with_or_without_schema_name)
+
         table_name, _schema_name, namespace_name = get_db_object_names(table_name_with_or_without_schema_name)
 
         fk_info = select_all %{
@@ -51,7 +52,7 @@ module Foreigner
           extras << 'NOT VALID'                  if row['valid'] == 'f'
           options[:options] = extras.join(" ")
 
-          ForeignKeyDefinition.new(table_name, row['to_table'], options)
+          ForeignKeyDefinition.new(table_name_with_or_without_schema_name, row['to_table'], options)
         end
       end
     end

--- a/lib/foreigner/connection_adapters/postgresql_adapter.rb
+++ b/lib/foreigner/connection_adapters/postgresql_adapter.rb
@@ -6,6 +6,9 @@ module Foreigner
       DEPENDENCY_CODE_ACTIONS = {'c' => 'CASCADE', 'n' => 'SET NULL', 'r' => 'RESTRICT', 'd' => 'SET DEFAULT'}
 
       def foreign_keys(table_name)
+        table_name_without_schema = table_name.split('.').last
+        schema_name = table_name.split('.').first
+
         fk_info = select_all %{
           SELECT t2.relname AS to_table
                , a1.attname AS column
@@ -23,8 +26,8 @@ module Foreigner
           JOIN pg_attribute a2 ON a2.attnum = c.confkey[1] AND a2.attrelid = t2.oid
           JOIN pg_namespace t3 ON c.connamespace = t3.oid
           WHERE c.contype = 'f'
-            AND t1.relname = '#{table_name}'
-            AND t3.nspname = ANY (current_schemas(false))
+            AND t1.relname = '#{table_name_without_schema}'
+            AND t3.nspname = #{ explicit_schema?(table_name) ? "'"+ schema_name +"'" : "ANY (current_schemas(false))" }
           ORDER BY c.conname
         }
 

--- a/lib/foreigner/connection_adapters/sql2003.rb
+++ b/lib/foreigner/connection_adapters/sql2003.rb
@@ -20,8 +20,21 @@ module Foreigner
       end
 
       def add_foreign_key(from_table, to_table, options = {})
-        sql = "ALTER TABLE #{quote_proper_table_name(from_table)} #{add_foreign_key_sql(from_table, to_table, options)}"
-        execute(sql)
+        if should_add_foreign_key?(from_table, options)
+          sql = "ALTER TABLE #{quote_proper_table_name(from_table)} #{add_foreign_key_sql(from_table, to_table, options)}"
+          execute(sql)
+        end
+      end
+
+      # We do not add foreign key to public schema, if it already exists.
+      def should_add_foreign_key?(from_table, options)
+        explicit_schema = explicit_schema?(from_table)
+
+        ( explicit_schema && !foreign_key_exists?(from_table, options) ) || !explicit_schema
+      end
+
+      def explicit_schema?(from_table)
+        from_table.is_a?(String) && from_table.include?('.')
       end
 
       def add_foreign_key_sql(from_table, to_table, options = {})

--- a/lib/foreigner/connection_adapters/sql2003.rb
+++ b/lib/foreigner/connection_adapters/sql2003.rb
@@ -33,7 +33,7 @@ module Foreigner
         return false unless Object.const_defined?(:Apartment)
 
         _table_name, schema_name, _namespace_name = get_db_object_names(from_table)
-        schema_name && schema_name == Apartment.default_schema && foreign_key_exists?(from_table, options)
+        schema_name && schema_name == Apartment.default_schema.to_s && foreign_key_exists?(from_table, options)
       end
 
       def schema_specified?(table_name)
@@ -96,8 +96,9 @@ module Foreigner
       end
 
       private
-        def foreign_key_name(from_table, column)
-          "#{from_table}_#{column}_fk"
+        def foreign_key_name(table_name, column_with_schema_name)
+          column, _schema_name, _namespace_name = get_db_object_names(column_with_schema_name)
+          "#{table_name}_#{column}_fk"
         end
 
         def foreign_key_column(to_table)

--- a/lib/foreigner/connection_adapters/sql2003.rb
+++ b/lib/foreigner/connection_adapters/sql2003.rb
@@ -33,7 +33,7 @@ module Foreigner
         return false unless Object.const_defined?(:Apartment)
 
         _table_name, schema_name, _namespace_name = get_db_object_names(from_table)
-        schema_name && schema_name == Apartment.default_schema.to_s && foreign_key_exists?(from_table, options)
+        schema_name && schema_name == Apartment.default_schema && foreign_key_exists?(from_table, options)
       end
 
       def schema_specified?(table_name)

--- a/test/foreigner/connection_adapters/postgresql_adapter_test.rb
+++ b/test/foreigner/connection_adapters/postgresql_adapter_test.rb
@@ -2,5 +2,69 @@ require 'helper'
 require 'foreigner/connection_adapters/postgresql_adapter'
 
 class Foreigner::PostgreSQLAdapterTest < Foreigner::UnitTest
-  include Foreigner::ConnectionAdapters::PostgreSQLAdapter
+  class PostgreSQLAdapter
+    include TestAdapterMethods
+    include Foreigner::ConnectionAdapters::PostgreSQLAdapter
+  end
+
+  setup do
+    @adapter = PostgreSQLAdapter.new
+  end
+
+  test 'foreign_keys parsing' do
+    @adapter.expects(:postgresql_version).at_least_once.returns(90404)
+    @adapter.expects(:select_all).with(%{
+          SELECT t2.relname AS to_table
+               , a1.attname AS column
+               , a2.attname AS primary_key
+               , c.conname AS name
+               , c.confdeltype AS dependency
+               , c.confupdtype AS update_dependency
+               , c.condeferrable AS deferrable
+               , c.condeferred AS deferred
+            , c.convalidated AS valid
+          FROM pg_constraint c
+          JOIN pg_class t1 ON c.conrelid = t1.oid
+          JOIN pg_class t2 ON c.confrelid = t2.oid
+          JOIN pg_attribute a1 ON a1.attnum = c.conkey[1] AND a1.attrelid = t1.oid
+          JOIN pg_attribute a2 ON a2.attnum = c.confkey[1] AND a2.attrelid = t2.oid
+          JOIN pg_namespace t3 ON c.connamespace = t3.oid
+          WHERE c.contype = 'f'
+            AND t1.relname = 'bar'
+            AND t3.nspname = ANY (current_schemas(false))
+          ORDER BY c.conname
+        }).at_least_once.returns([{'column' => 'foo_id', 'name' => 'foo_bar_foo_id_fk', 'primary_key' => 'id', 'to_table' => 'foo'}])
+
+    assert_equal Foreigner::ConnectionAdapters::ForeignKeyDefinition.new('bar', 'foo', {column:"foo_id", name:"foo_bar_foo_id_fk", primary_key:"id", dependent:nil, options:""}),
+                 @adapter.foreign_keys('bar').first
+  end
+
+  test 'foreign_keys parsing with schema specified' do
+    @adapter.expects(:postgresql_version).at_least_once.returns(90404)
+    @adapter.expects(:select_all).with(%{
+          SELECT t2.relname AS to_table
+               , a1.attname AS column
+               , a2.attname AS primary_key
+               , c.conname AS name
+               , c.confdeltype AS dependency
+               , c.confupdtype AS update_dependency
+               , c.condeferrable AS deferrable
+               , c.condeferred AS deferred
+            , c.convalidated AS valid
+          FROM pg_constraint c
+          JOIN pg_class t1 ON c.conrelid = t1.oid
+          JOIN pg_class t2 ON c.confrelid = t2.oid
+          JOIN pg_attribute a1 ON a1.attnum = c.conkey[1] AND a1.attrelid = t1.oid
+          JOIN pg_attribute a2 ON a2.attnum = c.confkey[1] AND a2.attrelid = t2.oid
+          JOIN pg_namespace t3 ON c.connamespace = t3.oid
+          WHERE c.contype = 'f'
+            AND t1.relname = 'bar'
+            AND t3.nspname = 'public'
+          ORDER BY c.conname
+        }).at_least_once.returns([{'column' => 'foo_id', 'name' => 'foo_bar_foo_id_fk', 'primary_key' => 'id', 'to_table' => 'foo'}])
+
+    assert_equal Foreigner::ConnectionAdapters::ForeignKeyDefinition.new('public.bar', 'foo', {column:"foo_id", name:"foo_bar_foo_id_fk", primary_key:"id", dependent:nil, options:""}),
+                 @adapter.foreign_keys('public.bar').first
+
+  end
 end

--- a/test/foreigner/connection_adapters/sql2003_test.rb
+++ b/test/foreigner/connection_adapters/sql2003_test.rb
@@ -118,6 +118,23 @@ class Foreigner::Sql2003Test < Foreigner::UnitTest
     )
   end
 
+  test 'when apartment, when schema not specified, adds foreign key' do
+    begin
+      class ::Apartment
+        def self.default_schema
+          :public
+        end
+      end
+
+      assert_equal(
+        "ALTER TABLE `roles_users` ADD CONSTRAINT `roles_users_role_id_fk` FOREIGN KEY (`role_id`) REFERENCES `roles`(id)",
+        @adapter.add_foreign_key('roles_users', 'roles')
+      )
+    ensure
+      Object.send(:remove_const, :Apartment)
+    end
+  end
+
   test 'when apartment, when schema specified, adds foreign key' do
     begin
       class ::Apartment
@@ -136,7 +153,7 @@ class Foreigner::Sql2003Test < Foreigner::UnitTest
     end
   end
 
-  test 'when schema specified, skips add foreign key if it already exists' do
+  test 'when apartment, when schema specified, skips add foreign key if it already exists' do
     begin
       class ::Apartment
         def self.default_schema


### PR DESCRIPTION
This PR solves two problems which are highly relevant if you are either using explicit schema names in add_foreign_key instructions, and/or you are using the Apartment gem.
1. Incorrect behaviour of using foreign keys in conjunction with schema name (see Example 1)
2. Unfavorable behaviour when using Apartment gem. When creating a new tenant, Apartment will create a new schema with specified name and load schema.rb. schema.rb as we all know contains add_foreign_key statements, some of which may reference the public (shared) schema (i e public foreign keys). In current version of foreigner this will throw an exception because the FKs already exists!
   - We need to let foreigner skip adding foreign key if:
     - Apartment gem is in use
     - Foreign key instruction wants to add to public (shared) schema
     - Foreign key already exist

We have patched the gem in our production environment and would like to share it with the main repo.

Example 1:

``` ruby
add_foreign_key "public.roles_users", "public.roles", :name => "roles_users_role_id_fk", :dependent => :delete, :column => "role_id"
```

With foreigner v1.7.4 we will get this sql:

``` sql
"ALTER TABLE `public`.`roles_users` ADD CONSTRAINT `public.roles_users_public.role_id_fk` FOREIGN KEY (`public.role_id`) REFERENCES `public`.`roles`(id)"
```

What is expected is this sql:

``` sql
"ALTER TABLE `public`.`roles_users` ADD CONSTRAINT `public.roles_users_role_id_fk` FOREIGN KEY (`public.role_id`) REFERENCES `public`.`roles`(id)"
```
