### PR TITLE
register Makara as mysql2 adapter

### DIFF
--- a/lib/foreigner.rb
+++ b/lib/foreigner.rb
@@ -26,6 +26,7 @@ end
 
 Foreigner::Adapter.register 'mysql', 'foreigner/connection_adapters/mysql_adapter'
 Foreigner::Adapter.register 'mysql2', 'foreigner/connection_adapters/mysql2_adapter'
+Foreigner::Adapter.register 'mysql2_makara', 'foreigner/connection_adapters/mysql2_adapter'
 Foreigner::Adapter.register 'jdbcmysql', 'foreigner/connection_adapters/mysql2_adapter'
 Foreigner::Adapter.register 'postgresql', 'foreigner/connection_adapters/postgresql_adapter'
 Foreigner::Adapter.register 'postgis', 'foreigner/connection_adapters/postgresql_adapter'


### PR DESCRIPTION
Trying to use the mysql2_makara adapter with Foreigner as in a rake task i was getting the error:
 [exec] "Database adapter mysql2_makara not supported. Use:\nForeigner::Adapter.register 'mysql2_makara', 'path/to/adapter'"
Thanks.
